### PR TITLE
Mocking doens't work if you call `get` instead of `simple_request`

### DIFF
--- a/lib/Test/Mock/LWP/Dispatch.pm
+++ b/lib/Test/Mock/LWP/Dispatch.pm
@@ -232,13 +232,10 @@ Deletes all mappings.
          unmap_all      => \&unmap_all,
     );
 
-    $mock_ua = Test::MockObject->new();
-    $mock_ua->set_isa('LWP::UserAgent');
-
-    $mock_ua->fake_module('LWP::UserAgent', %mock_methods);
-    while (my ($method, $handler) = each %mock_methods) {
-        $mock_ua->mock($method, $handler);
-    }
+    Test::MockObject->fake_module('LWP::UserAgent', %mock_methods);
+    # The global mock object, can be used directly, or can just create a new
+    # LWP::UserAgent object - that is mocked too.
+    $mock_ua = LWP::UserAgent->new;
 }
 
 1;

--- a/t/ua_requests.t
+++ b/t/ua_requests.t
@@ -1,0 +1,12 @@
+#!perl
+use strict;
+use warnings;
+use Test::More;
+use Test::Mock::LWP::Dispatch;
+
+# Test that 'get' etc on the global mock UA works.
+$mock_ua->map('http://example.com/a', HTTP::Response->new(201));
+
+is $mock_ua->get('http://example.com/a')->code, 201, "Can mock GET on global mock UA";
+
+done_testing;


### PR DESCRIPTION
So the code I'm testing does `$ua->get` and as it stands currently this dist just yields a warning of `Un-mocked method 'get()' called` instead of checking the map. 

A simple example that I'd expect to work:

``` perl
use strictures 1;
use Test::More;
use Test::Mock::LWP::Dispatch;

my $url = "http://example.com/a";
$mock_ua->map( $url, HTTP::Response->new(200, 'OK', [], '<html><p>Hi!</p>') );

is 200, $mock_ua->get( $url )->code;
done_testing;
```

Should this work and I've just done something wrong? A look at the code and Test::MockObject appears not.

However using Test::MockObject::Extends instead looks like it will solve all this for us, for example this behaves as expected:

``` perl
use strictures 1;
use Test::More;
use Test::MockObject::Extends;
use Test::Mock::LWP::Dispatch;

my $mock_ua = Test::MockObject::Extends->new("LWP::UserAgent");
$mock_ua->mock( simple_request => Test::Mock::LWP::Dispatch->can('simple_request') );
$mock_ua->mock( map => Test::Mock::LWP::Dispatch->can('map') );

my $url = "http://example.com/a";
$mock_ua->map( $url, HTTP::Response->new(200, 'OK', [], '<html><p>Hi!</p>') );

is 200, $mock_ua->get( $url )->code;
done_testing;
```

Any reason not to use ::Extends instead? If you are open to this I'll create a pull request tomorrow that switches over to using this approach.
