### PR TITLE
Mocked requests do not contain default headers normally set by LWP::UserAgent

### DIFF
--- a/lib/Test/Mock/LWP/Dispatch.pm
+++ b/lib/Test/Mock/LWP/Dispatch.pm
@@ -43,6 +43,7 @@ use base qw(Exporter Test::MockObject);
 
 our @EXPORT = qw($mock_ua);
 our @EXPORT_OK = @EXPORT;
+our $DEFAULT_REQUEST_HEADERS=0;
 
 use Carp qw(croak);
 use Data::Dumper qw();
@@ -78,6 +79,8 @@ Be accurate: method loops through mappings in order of adding these mappings.
     sub simple_request {
         my $mo = shift;
         my $in_req = shift;
+        $in_req = $mo->prepare_request($in_req)
+          if ( $DEFAULT_REQUEST_HEADERS && $mo->can('prepare_request') );
 
         my $global_maps = $mock_ua->{_maps} || [];
         my $local_maps = $mo->{_maps} || [];
@@ -87,6 +90,8 @@ Be accurate: method loops through mappings in order of adding these mappings.
             my ($req, $resp) = @{$map};
 
             if (ref($req) eq 'HTTP::Request') {
+                $req = $mo->prepare_request($req)
+                  if ( $DEFAULT_REQUEST_HEADERS && $mo->can('prepare_request') );
                 my $dd = Data::Dumper->new([$in_req]);
                 my $dd_in = Data::Dumper->new([$req]);
                 $dd->Sortkeys(1);
@@ -244,6 +249,25 @@ Deletes all mappings.
 1;
 
 __END__
+=head1 SWITCHES
+
+=head2 DEFAULT_REQUEST_HEADERS
+
+LWP::UserAgent sets default headers for requests by calling
+LWP::UserAgent->prepare_request().
+
+This function never gets called when using Test::Mock::LWP::Dispatch 
+due to LWP::UserAgent::simple_request() being overridden.
+
+This makes it impossible to write tests around headers such as User-Agent or an
+Authentication header set through $lwp->default_headers->authorization_basic.
+
+An optional switch has been added which runs prepare_request() against requests
+intercepted by Test::Mock::LWP::Dispatch. 
+
+To enable this switch set the following variable in your test:
+
+$Test::Mock::LWP::Dispatch::DEFAULT_REQUEST_HEADERS=1;
 
 =head1 MISCELLANEOUS
 

--- a/t/default_headers.t
+++ b/t/default_headers.t
@@ -1,0 +1,27 @@
+#!perl
+use strict;
+use warnings;
+use Test::More tests => 4;
+use Test::Mock::LWP::Dispatch;
+$Test::Mock::LWP::Dispatch::DEFAULT_REQUEST_HEADERS=1;
+use Data::Dumper;
+my $ua = LWP::UserAgent->new;
+$ua->agent('custom useragent');
+$ua->default_headers->authorization_basic( 'antipasta', 'password' );
+$ua->default_header(foo => 'bar');
+$ua->map(
+    'http://localhost',
+    sub {
+        my $req = shift;
+        is $req->header('user-agent'), 'custom useragent',
+          'Got correct useragent header';
+        ok $req->header('Authorization'), 'Got authorization header';
+        is scalar( $req->headers->authorization_basic ), 'antipasta:password',
+          'Contents of authorization_basic are correct';
+        is $req->header('foo'),'bar', 'Got custom header foo';
+
+        return HTTP::Response->new( 200, 'OK');
+    }
+);
+$ua->get('http://localhost');
+done_testing;


### PR DESCRIPTION
Hi,

I've been using your module quite a bit when testing code built around LWP::UserAgent. I usually test using the ->map($site, $coderef) method, and in the $coderef I test against the HTTP::Request object that is passed into it, to make sure that it has everything I expect it to.

Today I noticed that authorization headers were missing from the HTTP::Request objects that were being created when doing $lwp->get() when using Test::Mock::LWP::Dispatch.

It took a little digging into LWP::UserAgent, but I realized that 'default' headers are added to requests by prepare_request(), which is called by send_request() in LWP::UserAgent.

Since your module mocks simple_request, send_request() is never called, so prepare_request() is also never called.

The test case I've included better illustrates what I'm talking about. It fails against master currently.

I didn't want to break backwards compatibility by making drastic changes, so this pull request just adds a switch that calls prepare_request() against any HTTP::Request objects passed into your module's simple_request function. So when this switch is set to 1 in a test case, it fixes the issues I was running into.

Your full test suite still passes if we always used prepare_request() and didn't rely on the switch, so it's up to you whether running prepare_request() should be the default or not.

Let me know if you have any about the change, or suggestions on how it can be improved upon so that it can be merged.

Joe Papperello
