### PR TITLE
Ability to pass trough requests to real LWP::UserAgent

### DIFF
--- a/t/map_passtrough.t
+++ b/t/map_passtrough.t
@@ -1,0 +1,17 @@
+#!perl
+use strict;
+use warnings;
+use Test::More tests => 3;
+use Test::Mock::LWP::Dispatch ();
+use FindBin '$Bin';
+
+my $ua = LWP::UserAgent->new;
+
+is($ua->get("file://$Bin")->code, 404, 'before map');
+
+my $index1 = $ua->map_passtrough(qr{^file://});
+
+is($ua->get("file://$Bin")->code, 200, 'after map');
+
+$ua->unmap($index1);
+is($ua->get("file://$Bin")->code, 404, 'after unmap');


### PR DESCRIPTION
We use this to be able to let some requests go trough, say `file://` links, but also links to other live servers we need for tests to pass.