### PR TITLE
Fix test so it passes on Windows too

### DIFF
--- a/t/map_passthrough.t
+++ b/t/map_passthrough.t
@@ -10,6 +10,7 @@ use FindBin qw($Bin $Script);
 
 my $ua = LWP::UserAgent->new;
 my $url = "file://" . catfile($Bin, $Script);
+$url =~ s!\\!/!g; # fix path names on Windows
 
 is($ua->get($url)->code, 404, 'before map');
 


### PR DESCRIPTION
Windows uses "\" as path delimiter, which won't be recognized in a `file://` URL. This converts all backslashes to forward slashes and then the test passes on Windows as well.